### PR TITLE
Begin styling splash

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, Switch } from "react-router-dom";
 import { connect } from "react-redux";
 import * as actions from "../actions";
 
@@ -20,8 +20,10 @@ class App extends React.Component {
       <div className="container">
         <BrowserRouter>
           <div>
-            <Header />
-            <AuthRoute exact path="/" component={Splash} />
+            <Switch>
+              <AuthRoute exact path="/" component={Splash} />
+              <Header />
+            </Switch>
             <ProtectedRoute exact path="/dashboard" component={Dashboard} />
             <ProtectedRoute exact path="/projects/1/1" component={Project} />
             <ProtectedRoute exact path="/documents/1" component={Document} />

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -7,14 +7,6 @@ class Header extends React.Component {
     switch (this.props.auth) {
       case null:
       return;
-      case false:
-      return (
-        <ul className="right">
-          <li>
-            <a href="/auth/google">Sign in with Google</a>
-          </li>
-        </ul>
-      );
       default:
       return (
         <ul className="right">

--- a/client/src/components/Splash.jsx
+++ b/client/src/components/Splash.jsx
@@ -8,7 +8,7 @@ const Splash = () => {
         The tool that writers can't live without.
         Maintain countless drafts and still maintain your sanity.
       </h4>
-              <a href="/auth/google">Sign in with Google</a>
+      <a href="/auth/google">Sign in with Google</a>
     </div>
   );
 };

--- a/client/src/components/Splash.jsx
+++ b/client/src/components/Splash.jsx
@@ -8,6 +8,7 @@ const Splash = () => {
         The tool that writers can't live without.
         Maintain countless drafts and still maintain your sanity.
       </h4>
+              <a href="/auth/google">Sign in with Google</a>
     </div>
   );
 };


### PR DESCRIPTION
Added Switch statement to App.jsx to either display the Splash or Header. Then moved sign in button onto Splash page. Removed unnecessary code from Header since user can only sign in from the Splash page. User unable to navigate to Splash page unless signed out. This was just to better reflect how our wireframes look since the splash page has no nav bar!