### PR TITLE
Added draft-js-export-html library to package json, added immutable

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2805,6 +2805,19 @@
         }
       }
     },
+    "draft-js-export-html": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/draft-js-export-html/-/draft-js-export-html-1.2.0.tgz",
+      "integrity": "sha1-HL4reOH+10/CnHzcv9dUBGjsogk=",
+      "requires": {
+        "draft-js-utils": "1.2.0"
+      }
+    },
+    "draft-js-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.2.0.tgz",
+      "integrity": "sha1-9csj6xZzJf/tPXmIL9wxdyHS/RI="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -5367,6 +5380,11 @@
       "requires": {
         "minimatch": "3.0.4"
       }
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-lazy": {
       "version": "2.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "axios": "^0.18.0",
     "draft-js": "^0.10.5",
+    "draft-js-export-html": "^1.2.0",
+    "immutable": "^3.8.2",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-redux": "^5.0.7",

--- a/client/src/components/DocumentForm.jsx
+++ b/client/src/components/DocumentForm.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Editor, EditorState, RichUtils } from 'draft-js';
+import { Editor, EditorState, RichUtils, convertToRaw } from 'draft-js';
 import { connect } from 'react-redux';
 import '../styles/documentForm.css';
 import '../styles/stylingMain.css';
+import {stateToHTML} from 'draft-js-export-html';
 import ul from '../assets/ul-icon.png';
 class DocumentForm extends React.Component {
   constructor(props) {
@@ -13,6 +14,10 @@ class DocumentForm extends React.Component {
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
     this.onTab = (e) => this._onTab(e);
   }
+
+  // display() {
+  //   let thing = stateToHTML(this.state.editorState.getCurrentContent());
+  // }
 
   handleStyleClick(type) {
     this.onChange(RichUtils.toggleInlineStyle(this.state.editorState, type));
@@ -93,8 +98,9 @@ class DocumentForm extends React.Component {
           onChange={this.onChange}
           handleKeyCommand={this.handleKeyCommand}
           onTab={this.onTab}
+          spellCheck={!this.spellCheck}
           />
-      </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Added libraries to help convert draft js forms into html
included immutable as well since it is a dependency
added spellcheck to our form
included on the WIKI an example of how to use draft-js-export-html