### PR TITLE
Prepare docu form for edits

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -8,7 +8,8 @@ import {
   FETCH_SAVE,
   FORM_ERROR,
   FETCH_SAVES,
-  FETCH_DRAFT
+  FETCH_DRAFT,
+  FETCH_REVISION
 } from './types';
 
 export const fetchProjects = () => async dispatch => {
@@ -25,6 +26,15 @@ export const fetchProject = id => async dispatch => {
     project: res.data.project,
     drafts: res.data.drafts
   });
+}
+
+export const fetchRevision = id => async dispatch => {
+  const res = await axios.get(`/api/revision/${id}`)
+
+  dispatch({
+    type: FETCH_REVISION,
+    revision: res.data.revision
+  })
 }
 
 export const fetchDraft = id => async dispatch => {

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -15,3 +15,5 @@ export const FETCH_SAVE = "FETCH_SAVE";
 export const FORM_ERROR = "FORM_ERROR";
 
 export const FETCH_DRAFT = "FETCH_DRAFT";
+
+export const FETCH_REVISION = "FETCH_REVISION";

--- a/client/src/components/DocumentForm.jsx
+++ b/client/src/components/DocumentForm.jsx
@@ -5,7 +5,7 @@ import '../styles/documentForm.css';
 import '../styles/stylingMain.css';
 import {stateToHTML} from 'draft-js-export-html';
 import ul from '../assets/ul-icon.png';
-import { fetchRevision } from '../actions/index';
+import { fetchRevision, openModal, closeModal } from '../actions/index';
 import debounce from 'lodash/debounce';
 class DocumentForm extends React.Component {
   constructor(props) {

--- a/client/src/components/DocumentForm.jsx
+++ b/client/src/components/DocumentForm.jsx
@@ -1,30 +1,44 @@
 import React from 'react';
-import { Editor, EditorState, RichUtils, convertToRaw } from 'draft-js';
+import { Editor, EditorState, RichUtils, convertToRaw, convertFromRaw } from 'draft-js';
 import { connect } from 'react-redux';
 import '../styles/documentForm.css';
 import '../styles/stylingMain.css';
 import {stateToHTML} from 'draft-js-export-html';
 import ul from '../assets/ul-icon.png';
+import { fetchRevision } from '../actions/index';
+import debounce from 'lodash/debounce';
 class DocumentForm extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
+
     this.focus = () => this.refs.editor.focus();
-    this.state = { };
-    this.onChange = (editorState) => this.setState({editorState});
+    this.onChange = this.onChange.bind(this);
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
     this.onTab = (e) => this._onTab(e);
     this.handleSave = this.handleSave.bind(this);
   }
 
-  // display() {
-  //   let thing = stateToHTML(this.state.editorState.getCurrentContent());
-  // }
+  saveContent = debounce((content) => {
+    console.log("hello");
+  }, 1000);
+
+  onChange(editorState) {
+    this.saveContent();
+    this.setState({editorState});
+  }
+
+
+
   componentDidMount () {
-    let here = "this is set up so we can insert any content we have already into the form";
-    let hi = "so we can reuse this form for editing and possibly making readOnly here";
-    this.setState({
-      editorState: EditorState.createEmpty()
-    });
+    let found = false; //Here we would do the fetchRevision to do this we need the revision id which would be created when we create the empty document
+    if (found) {
+      this.setState({
+        editorState: EditorState.createWithContent(convertFromRaw(found))
+      })
+    } else {
+      this.setState({editorState: EditorState.createEmpty()})
+    }
   }
 
   handleStyleClick(type) {
@@ -47,7 +61,7 @@ class DocumentForm extends React.Component {
   }
 
   handleSave() {
-    let stuff = "happen here set up for doing commits here";
+
   }
 
   handleBlockClick(type) {
@@ -128,5 +142,9 @@ function mapStateToProps(state) {
   return { document: { name: "Chapter One" },
           save: {comment: 'Not fact checked'}};
 }
+
+const mapDispatchToProps = (dispatch) => ({
+  fetchRevision: (id) => dispatch(fetchRevision(id))
+});
 
 export default connect(mapStateToProps)(DocumentForm);

--- a/client/src/components/ProjectsListItem.jsx
+++ b/client/src/components/ProjectsListItem.jsx
@@ -7,6 +7,9 @@ class ProjectsListItem extends React.Component {
   render() {
 
     const { project, users } = this.props;
+    if (Object.keys(users).length === 0) {
+      return <div>Loading...</div>
+    }
     return (
       <li className='list-item'>
         <div className='list-name'>

--- a/client/src/reducers/revisionsReducer.js
+++ b/client/src/reducers/revisionsReducer.js
@@ -1,6 +1,6 @@
 import { merge, mapValues } from 'lodash';
 
-import { FETCH_SAVE } from '../actions/types';
+import { FETCH_SAVE, FETCH_REVISION } from '../actions/types';
 
 export default (state = {}, action) => {
   switch (action.type) {
@@ -12,6 +12,8 @@ export default (state = {}, action) => {
           merge({ body: { entityMap: {} } }, rev)
         )
       );
+    case FETCH_REVISION:
+      return merge({}, state, action.revision);
     default:
       return state;
   }


### PR DESCRIPTION
Document form page is almost prepared to begin receiving fetchRequest for the revision in order to be used for editing a document
Still missing some items from the previous page, i need a revisionId to be able to fetch the proper revision, clicking on a revision on the project show page should have that information
Also created a proof of concept that auto saving could be easily implemented. currently it prints hello after the user stops typing. we can adjust the timing on when it executes. it console logs after 1 second of inactivity
Minor hot fix to add loading for project list items in the dashboard