### PR TITLE
Quick fix

### DIFF
--- a/client/src/components/DocumentForm.jsx
+++ b/client/src/components/DocumentForm.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Editor, EditorState, RichUtils, convertToRaw, convertFromRaw } from 'draft-js';
+import { Editor, EditorState, RichUtils,
+  convertToRaw, convertFromRaw, getDefaultKeyBinding,
+  KeyBindingUtil } from 'draft-js';
 import { connect } from 'react-redux';
 import '../styles/documentForm.css';
 import '../styles/stylingMain.css';
@@ -9,7 +11,10 @@ import { openModal, closeModal, createSave, fetchRevision } from '../actions/ind
 import debounce from 'lodash/debounce';
 import SaveRev from './SaveRev';
 import TitleErrorModal from './TitleErrorModal';
+
+const {hasCommandModifier} = KeyBindingUtil;
 class DocumentForm extends React.Component {
+
   constructor(props) {
     super(props);
     this.state = {
@@ -26,6 +31,13 @@ class DocumentForm extends React.Component {
     this.update = this.update.bind(this);
     this.makeSaveReq = this.makeSaveReq.bind(this);
     this.createSave = this.createSave.bind(this);
+  }
+
+  myKeyBindingFn(e: SyntheticKeyboardEvent): string {
+    if (e.keyCode === 83 && hasCommandModifier(e)) {
+      return 'save';
+    }
+    return getDefaultKeyBinding(e);
   }
 
   saveTitle = debounce(() => {
@@ -71,6 +83,16 @@ class DocumentForm extends React.Component {
   }
 
   handleKeyCommand(command, editorState) {
+    if (command === 'save') {
+      this.props.openModal(
+        <SaveRev
+          projectId={this.props.match.params.projectId}
+          document={this.props.document}
+          title={this.state.title}
+          draftId={this.props.draft._id}
+          body={convertToRaw(this.state.editorState.getCurrentContent())}
+        />);
+    }
     const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {
       this.onChange(newState);
@@ -91,7 +113,7 @@ class DocumentForm extends React.Component {
     let body = convertToRaw(this.state.editorState.getCurrentContent());
     return Object.assign({}, {
       save: {name: typeofSave,
-        draftId: this.props.draft._id, isAuto: auto},
+      draftId: this.props.draft._id, isAuto: auto},
       newRevs: [{title: this.state.title,
       body: body}],
       deletedRevIds: [this.props.document._id]
@@ -192,6 +214,7 @@ class DocumentForm extends React.Component {
               handleKeyCommand={this.handleKeyCommand}
               onTab={this.onTab}
               spellCheck={!this.spellCheck}
+              keyBindingFn={this.myKeyBindingFn}
               />
           </div>
         </section>

--- a/client/src/components/TitleEditForm.jsx
+++ b/client/src/components/TitleEditForm.jsx
@@ -15,6 +15,10 @@ class TitleEditForm extends React.Component {
     this.update = this.update.bind(this);
   }
 
+  componentWillUnmount() {
+    this.props.clearErrors();
+  }
+
   update(field) {
     return e =>
       this.setState({
@@ -30,7 +34,6 @@ class TitleEditForm extends React.Component {
         newRevs: [{title: this.state.title, body: this.props.document.body}],
         deletedRevIds: [this.props.document._id]
     });
-    console.log(save);
     this.props.clearErrors();
     this.props.createSave(save).then(this.checkErrors.bind(this));
   }
@@ -58,8 +61,8 @@ class TitleEditForm extends React.Component {
           <input id="required-input"
             className="new-form name"
             type="text"
-            placeholder={this.state.title}
             onChange={this.update('title')}
+            value={this.state.title}
           />
           {this.renderErrors()}
           <input


### PR DESCRIPTION
Title now appears on modal when editing instead of being placeholder text to allow users to add on to the text if they wish
Added hot key to save using ctrl+s or cmd+s to bring up save modal
Clear errors after leaving modal on title change errors