### PR TITLE
quick update to fix redirect when changing title names on document form

### DIFF
--- a/client/src/components/DocumentForm.jsx
+++ b/client/src/components/DocumentForm.jsx
@@ -171,7 +171,9 @@ class DocumentForm extends React.Component {
   }
 
   createSave(save) {
+    let title = this.state.title;
     this.props.createSave(save).then((payload) => {
+      this.props.history.replace(`/project/${this.props.projectId}/document/${title}`)
     }).catch( () => {
       this.props.openModal(<TitleErrorModal />)
       this.setState({


### PR DESCRIPTION
quick fix to correctly redirect when saving so if you change the title on the document form it redirects you correctly